### PR TITLE
修复断点续传BUG

### DIFF
--- a/Assets/Plugins/XAsset/Download.cs
+++ b/Assets/Plugins/XAsset/Download.cs
@@ -124,7 +124,7 @@ namespace Plugins.XAsset
                         { 
                             fs.Seek(len, SeekOrigin.Begin);
                             request = UnityWebRequest.Get(url);
-                            request.SetRequestHeader("Range", "bytes=" + len + "-" + maxlen);
+                            request.SetRequestHeader("Range", "bytes=" + len + "-");
                             #if UNITY_2017_1_OR_NEWER
                             request.SendWebRequest();
                             #else


### PR DESCRIPTION
问题代码：
https://github.com/xasset/xasset/blob/7f9b9e59a7c6eead8f82393f38b37e2f7e430463/Assets/Plugins/XAsset/Download.cs#L127

应改为：
    `request.SetRequestHeader("Range", "bytes=" + len + "-" + (maxlen - 1));`

或者干脆改为：
   `request.SetRequestHeader("Range", "bytes=" + len + "-");`

详细参考：
[https://www.cnblogs.com/OIMM/p/9144798.html](https://www.cnblogs.com/OIMM/p/9144798.html)

多说两句：
我觉得这个maxlen的真正意义是为了分段下载，避免一次下载内容长度过长，导致内存占用过高。希望作者可以重新梳理下逻辑。